### PR TITLE
Add workflow_dispatch trigger to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
   pull_request:


### PR DESCRIPTION
Introduce a manual trigger for the build workflow to allow for on-demand execution.