### PR TITLE
Add checkout step for microsoft/BuildXL in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Checkout microsoft/BuildXL
+        uses: actions/checkout@v5
+        with:
+          repository: microsoft/BuildXL
+          path: BuildXL
+
       - name: List files
         shell: bash
         run: |


### PR DESCRIPTION
Include a step in the build workflow to checkout the microsoft/BuildXL repository.