### PR TITLE
Refactor build workflow to streamline execution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,13 @@ jobs:
           repository: microsoft/BuildXL
           path: BuildXL
 
-      - name: List files
-        shell: bash
+      # - name: List files
+      #   shell: bash
+      #   run: |
+      #     ls -la
+
+      - name: Run bxl.cmd
         run: |
-          ls -la
+          ./bxl.cmd -minimal
+        working-directory: ./BuildXL
+        shell: pwsh


### PR DESCRIPTION
Remove the file listing step in the build workflow and execute `bxl.cmd` with minimal options to enhance efficiency.