### PR TITLE
Update cache upload path to exclude old log files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,4 +87,5 @@ jobs:
           name: cache
           path: |
             ./BuildXL/Out/Cache/
+            !./BuildXL/Out/Cache/Shared/
             !./BuildXL/Out/Cache/**/LOG.old.*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,5 +87,4 @@ jobs:
           name: cache
           path: |
             ./BuildXL/Out/Cache/
-            !./BuildXL/Out/Cache/Shared/
             !./BuildXL/Out/Cache/**/LOG.old.*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,16 @@ jobs:
       #     restore-keys: |
       #       ${{ runner.os }}-nuget-
 
+      - name: Cache BuildXL
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-buildxl-release-${{ hashFiles('**/*.dsc') }}
+          path: ${{ env.DOMINO_CACHE_DIRECTORY }}
+          # path: ./BuildXL/Out/Cache
+          restore-keys: |
+            ${{ runner.os }}-buildxl-release-
+            ${{ runner.os }}-buildxl-
+
       - name: Restore cache
         run: |
           $Runs = gh run list --repo "${{ github.repository }}" --workflow build --branch main --status success --json number,databaseId,startedAt |
@@ -53,16 +63,6 @@ jobs:
           }
         continue-on-error: true
         shell: pwsh
-
-      - name: Cache BuildXL
-        uses: actions/cache@v4
-        with:
-          key: ${{ runner.os }}-buildxl-release-${{ hashFiles('**/*.dsc') }}
-          path: ${{ env.DOMINO_CACHE_DIRECTORY }}
-          # path: ./BuildXL/Out/Cache
-          restore-keys: |
-            ${{ runner.os }}-buildxl-release-
-            ${{ runner.os }}-buildxl-
 
       - name: Find the MSVC version
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,4 +85,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: cache
-          path: ./BuildXL/Out/Cache/
+          path: |
+            ./BuildXL/Out/Cache/
+            !./BuildXL/**/LOG.old.*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,15 +43,15 @@ jobs:
       #     restore-keys: |
       #       ${{ runner.os }}-nuget-
 
-      - name: Cache BuildXL
-        uses: actions/cache@v4
-        with:
-          key: ${{ runner.os }}-buildxl-release-${{ hashFiles('**/*.dsc') }}
-          path: ${{ env.DOMINO_CACHE_DIRECTORY }}
-          # path: ./BuildXL/Out/Cache
-          restore-keys: |
-            ${{ runner.os }}-buildxl-release-
-            ${{ runner.os }}-buildxl-
+      # - name: Cache BuildXL
+      #   uses: actions/cache@v4
+      #   with:
+      #     key: ${{ runner.os }}-buildxl-release-${{ hashFiles('**/*.dsc') }}
+      #     path: ${{ env.DOMINO_CACHE_DIRECTORY }}
+      #     # path: ./BuildXL/Out/Cache
+      #     restore-keys: |
+      #       ${{ runner.os }}-buildxl-release-
+      #       ${{ runner.os }}-buildxl-
 
       - name: Restore cache
         run: |


### PR DESCRIPTION
Modify the cache upload path to prevent old log files from being included in the upload process.